### PR TITLE
Don't parse as unicode something which may not be a string.

### DIFF
--- a/aiopulse/hub.py
+++ b/aiopulse/hub.py
@@ -158,7 +158,7 @@ class Hub:
 			_, ptr = unpack_bytes(message, ptr, 2)
 			scene_name, ptr = unpack_string(message, ptr)
 			_, ptr = unpack_bytes(message, ptr, 7)
-			_, ptr = unpack_string(message, ptr)
+			_, ptr = unpack_bytes(message, ptr)
 			_, ptr = unpack_bytes(message, ptr, 2)
 			if not scene_id in self.scenes:
 				self.scenes[scene_id] = Scene(self, scene_id)


### PR DESCRIPTION
While parsing the scene list on my hub, one of the chunks returned isn't valid unicode.  Since we just discard the value anyway, I've changed `unpack_string` to `unpack_bytes`, which solves the problem.
